### PR TITLE
Fix:オートコンプリート処理のbefore_actionを修正

### DIFF
--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -1,5 +1,5 @@
 class StaticPagesController < ApplicationController
-  skip_before_action :require_login, only: %i[index guide]
+  skip_before_action :require_login, only: %i[index search guide]
   before_action :set_category
   before_action :set_composer
   before_action :set_music


### PR DESCRIPTION
static_pages_controllerのsearchアクションにslip_before_actionを設定